### PR TITLE
Fix the comma substitution for templates list

### DIFF
--- a/nagios_reader_to_centreon_clapi.pl
+++ b/nagios_reader_to_centreon_clapi.pl
@@ -267,7 +267,7 @@ sub export_hosts {
 			my $type = "HOST";
 			my $host_name;
 			my $list_of_tpl = $host->use if ( defined ( $host->use ) );
-			$list_of_tpl =~ s/,/|/ if ( defined ( $host->use ) );;
+			$list_of_tpl =~ s/,/|/g if ( defined ( $host->use ) );;
 			#my $list_of_hostgroup = $host->use if ( defined ( $host->hostgroups ) );
 			#$list_of_hostgroup =~ s/,/|/ if ( defined ( $host->hostgroups ) );;
 			


### PR DESCRIPTION
The substitution was made on the first match only, made it global.